### PR TITLE
Fix accessibility string interpolation in PathWaypointNextArrivals

### DIFF
--- a/components/lines/PathWaypointNextArrivals/index.tsx
+++ b/components/lines/PathWaypointNextArrivals/index.tsx
@@ -47,6 +47,17 @@ export function PathWaypointNextArrivals({ realtimeArrivals, scheduledArrivals }
 		return toReturn;
 	};
 
+	const getRealtimeAccessibilityLabel = (unixTs: number) => {
+		const deltaMs = unixTs - now;
+		const totalMinutes = Math.floor(deltaMs / 1000 / 60);
+		const hours = Math.floor(totalMinutes / 60);
+		const minutes = totalMinutes % 60;
+
+		if (totalMinutes <= 0) return t('arriving');
+		if (hours > 0) return t('nextArrivalsRealtimeAccessibilityLabel', { hours, minutes });
+		return t('nextArrivalsRealtimeAccessibilityLabelMinutesOnly', { minutes });
+	};
+
 	//
 	// C. Render components
 
@@ -72,14 +83,14 @@ export function PathWaypointNextArrivals({ realtimeArrivals, scheduledArrivals }
 						<View style={pathWaypointNextArrivalsStyles.realtimeArrivalsList}>
 							{realtimeArrivals.map(realtimeArrival => realtimeArrival != undefined && (
 								<View key={realtimeArrival.unixTs}>
-									<Text
-										accessibilityHint={t('nextArrivalsRealtimeAccessibilityHint')}
-										accessibilityLabel={t('nextArrivalsRealtimeAccessibilityLabel', formatDelta(realtimeArrival.unixTs - now))}
-										accessibilityLanguage={localeContext.locale}
-										accessibilityRole="text"
-										style={pathWaypointNextArrivalsStyles.realtimeArrival}
-									>
-										{formatDelta(realtimeArrival.unixTs - now)}
+								<Text
+									accessibilityHint={t('nextArrivalsRealtimeAccessibilityHint')}
+									accessibilityLabel={getRealtimeAccessibilityLabel(realtimeArrival.unixTs)}
+									accessibilityLanguage={localeContext.locale}
+									accessibilityRole="text"
+									style={pathWaypointNextArrivalsStyles.realtimeArrival}
+								>
+									{formatDelta(realtimeArrival.unixTs - now)}
 									</Text>
 								</View>
 							))}
@@ -93,13 +104,13 @@ export function PathWaypointNextArrivals({ realtimeArrivals, scheduledArrivals }
 						<View style={pathWaypointNextArrivalsStyles.scheduledArrivalsList}>
 							{scheduledArrivals.slice(0, realtimeArrivals.length > 0 ? 3 : 4).map(scheduledArrival => scheduledArrival != undefined && (
 								<View key={scheduledArrival.unixTs}>
-									<Text
-										accessibilityHint={t('nextArrivalsRealtimeAccessibilityHint')}
-										accessibilityLabel={t('nextArrivalsRealtimeAccessibilityLabel', dayjs(scheduledArrival.unixTs).format('HH:mm'))}
-										accessibilityLanguage={localeContext.locale}
-										accessibilityRole="text"
-										style={pathWaypointNextArrivalsStyles.scheduledArrival}
-									>
+								<Text
+									accessibilityHint={t('nextArrivalsScheduledAccessibilityHint')}
+									accessibilityLabel={t('nextArrivalsScheduledAccessibilityLabel', { hours: dayjs(scheduledArrival.unixTs).format('HH'), minutes: dayjs(scheduledArrival.unixTs).format('mm') })}
+									accessibilityLanguage={localeContext.locale}
+									accessibilityRole="text"
+									style={pathWaypointNextArrivalsStyles.scheduledArrival}
+								>
 										{dayjs(scheduledArrival.unixTs).format('HH:mm')}
 									</Text>
 								</View>

--- a/i18n/translations/en.json
+++ b/i18n/translations/en.json
@@ -512,10 +512,11 @@
       "title": "Next circulations",
       "arriving": "Arriving",
       "nextArrivalsRealtimeAccessibilityHint": "Next trip in real time",
-      "nextArrivalsRealtimeAccessibilityLabel": "This arrival is in {time} minutes",
-      "nextArrivalsScheduledAccessibilityHint": "This arrival is scheduled ot {hours} and {minutes}",
-      "nextArrivalsScheduledAccessibilityLabel": "Next trip to {headsign} at {hours} hours and {minutes} minutes",
-      "nextArrivalsTitleAccessibilityHint": "This element is a text that indicates the next circulations",
+      "nextArrivalsRealtimeAccessibilityLabel": "Arrives in {hours} h {minutes} min, real-time",
+      "nextArrivalsRealtimeAccessibilityLabelMinutesOnly": "Arrives in {minutes} min, real-time",
+      "nextArrivalsScheduledAccessibilityHint": "Next scheduled trip",
+      "nextArrivalsScheduledAccessibilityLabel": "Scheduled at {hours}:{minutes}",
+      "nextArrivalsTitleAccessibilityHint": "Shows the bus arrivals coming soonest to this stop",
       "nextArrivalsTitleAccessibilityLabel": "Next circulations"
     },
     "PathStopTimetable": {

--- a/i18n/translations/pt.json
+++ b/i18n/translations/pt.json
@@ -513,10 +513,11 @@
 		"PathStopNextArrivals": {
 			"arriving": "A chegar",
 			"nextArrivalsRealtimeAccessibilityHint": "Próxima passagem em tempo real",
-			"nextArrivalsRealtimeAccessibilityLabel": "Esta passagem passa em {time} minutos",
-			"nextArrivalsScheduledAccessibilityHint": "Esta passagem está agendada para as {hours} horas e {minutes} minutos",
-			"nextArrivalsScheduledAccessibilityLabel": "Próxima passagem para {headsign} às {hours} horas e {minutes} minutos",
-			"nextArrivalsTitleAccessibilityHint": "Este elemento é um texto que indica as próximas circulações",
+			"nextArrivalsRealtimeAccessibilityLabel": "Chega em {hours} h {minutes} min, tempo real",
+			"nextArrivalsRealtimeAccessibilityLabelMinutesOnly": "Chega em {minutes} min, tempo real",
+			"nextArrivalsScheduledAccessibilityHint": "Próxima passagem agendada",
+			"nextArrivalsScheduledAccessibilityLabel": "Agendada para as {hours}:{minutes}",
+			"nextArrivalsTitleAccessibilityHint": "Indica as passagens do autocarro que chegam a esta paragem dentro de menos tempo",
 			"nextArrivalsTitleAccessibilityLabel": "Próximas circulações",
 			"title": "Próximas circulações"
 		},


### PR DESCRIPTION
- Pass {hours, minutes} to realtime accessibility labels matching formatDelta visual output, with edge cases for arriving now and minutes-only
- Fix scheduled arrivals using wrong Realtime translation keys, switch to Scheduled keys with {hours, minutes} interpolation
- Update EN/PT translation strings to be concise while clearly distinguishing realtime ("Arrives in X min") vs scheduled ("Scheduled at HH:MM")

Closes #9

Made-with: Cursor